### PR TITLE
Telemetry implementation on `payu run`

### DIFF
--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -23,6 +23,10 @@ from pathlib import Path
 
 # Extensions
 import yaml
+from colorama import Fore, Style
+from access_py_telemetry.api import ApiHandler
+from access_py_telemetry.decorators import register_func
+
 
 # Local
 from payu import envmod
@@ -50,6 +54,10 @@ default_restart_freq = 5
 class Experiment(object):
 
     def __init__(self, lab, reproduce=False, force=False, metadata_off=False):
+        
+        api_handler = ApiHandler()
+        api_handler.server_url = "http://testing-tunnel.ct1163.tm70.ps.gadi.nci.org.au:8000"
+
         self.lab = lab
 
         if not force:
@@ -663,6 +671,21 @@ class Experiment(object):
         # Dump job info
         with open(self.job_fname, 'w') as file:
             file.write(yaml.dump(info, default_flow_style=False))
+
+        info_lowercase = {key.lower(): val for key, val in info.items()}
+        # Add info to the telemetry server
+        ApiHandler().add_extra_fields("payu",info_lowercase)
+        ApiHandler().remove_fields("payu",["session_id"])
+        ApiHandler()._create_telemetry_record(service_name="payu",function_name="Experiment.run",
+                                              args=user_flags, kwargs={})
+
+        print(f"{Fore.GREEN}::: API: Collected the following telemetry data")
+        print(f"::: API: --> {ApiHandler()._extra_fields=}")
+        print(f"::: API: --> {ApiHandler().server_url=}")
+        print(f"::: API: --> {ApiHandler().endpoints=}")
+        print(f"::: API: --> {ApiHandler()._last_record=}")
+        print(f"{Style.RESET_ALL}")
+        ApiHandler().send_api_request("payu", "Experiment.run", (user_flags,), {})
 
         # Remove any empty output files (e.g. logs)
         for fname in os.listdir(self.work_path):

--- a/payu/laboratory.py
+++ b/payu/laboratory.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 
 import os
 import pwd
+from colorama import Fore, Style
 
 from payu.fsops import mkdir_p, read_config
 
@@ -16,6 +17,7 @@ class Laboratory(object):
 
     def __init__(self, model_type=None, config_path=None, lab_path=None):
         """Create the Payu laboratory interface."""
+        print(f"{Fore.YELLOW}Initialising laboratory with config {config_path} {Style.RESET_ALL}")
         config = read_config(config_path)
 
         # Set the file permission mask

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -8,6 +8,11 @@ import payu.subcommands.args as args
 from payu import fsops
 from payu.manifest import Manifest
 
+from colorama import Fore, Style
+
+from access_py_telemetry.api import ApiHandler
+
+
 title = 'run'
 parameters = {'description': 'Run the model experiment'}
 
@@ -18,6 +23,11 @@ arguments = [args.model, args.config, args.initial, args.nruns,
 
 def runcmd(model_type, config_path, init_run, n_runs, lab_path,
            reproduce=False, force=False, force_prune_restarts=False):
+
+    api_handler = ApiHandler()
+    api_handler.server_url = "http://testing-tunnel.ct1163.tm70.ps.gadi.nci.org.au:8000"
+
+    print(f"{Fore.YELLOW}Sending telemetry data to the server at {api_handler.server_url}.{Style.RESET_ALL}")
 
     # Get job submission configuration
     pbs_config = fsops.read_config(config_path)
@@ -107,20 +117,32 @@ def runcmd(model_type, config_path, init_run, n_runs, lab_path,
 
         pbs_config['mem'] = '{0}GB'.format(pbs_mem)
 
+    print(f"{Fore.YELLOW}Submitting job to the queue {pbs_config['queue']}.{Style.RESET_ALL}")
+
     cli.submit_job('payu-run', pbs_config, pbs_vars)
 
 
 def runscript():
 
+    # We have a new python interperter here, so we need to reconfigur the server url
+    api_handler = ApiHandler()
+    api_handler.server_url = "http://testing-tunnel.ct1163.tm70.ps.gadi.nci.org.au:8000"
+
     parser = argparse.ArgumentParser()
     for arg in arguments:
         parser.add_argument(*arg['flags'], **arg['parameters'])
 
+    print(f"{Fore.GREEN}Picked up submitted 'payu-run' job{Style.RESET_ALL}")
+
     run_args = parser.parse_args()
+    print(f"{Fore.BLUE}{run_args=}{Style.RESET_ALL}")
 
     lab = Laboratory(run_args.model_type, run_args.config_path,
                      run_args.lab_path)
+
+    print(f"{Fore.GREEN}Found lab {lab}.{Style.RESET_ALL}")
     expt = Experiment(lab, reproduce=run_args.reproduce, force=run_args.force)
+    print(f"{Fore.BLUE}Found experiment {expt}.{Style.RESET_ALL}")
 
     n_runs_per_submit = expt.config.get('runspersub', 1)
     subrun = 1


### PR DESCRIPTION
@jo-basevi @aidanheerdegen 

This is nowhere near ready to merge, but should hopefully demonstrate how we can get telemetry stats out of Payu.

The data collected from here looks like the following at present.

```
GET /payu/view
HTTP 200 OK
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

[
    {
        "id": 4,
        "timestamp": "2025-01-07T07:43:39.003507Z",
        "name": "ct1163",
        "function": "Experiment.run",
        "args": [
            []
        ],
        "kwargs": {},
        "payu_path": "/scratch/p73/ct1163/payu-venv/bin",
        "payu_control_dir": "/home/189/ct1163/mom6_double_gyre",
        "payu_run_id": "8f2fa40019547ab04b4a54e622586b00426be3c3",
        "payu_current_run": 6,
        "payu_n_runs": 1,
        "payu_job_status": 0,
        "payu_start_time": "2025-01-07T18:43:23.460908Z",
        "payu_finish_time": "2025-01-07T18:43:28.705671Z",
        "payu_walltime": "5.244763 s"
    }
]
```

I think we want to collect metadata too? If this is looking reasonably close to the mark for what we're looking to collect, we can begin to scope out the usage data we want to grab & where we want to grab it in more detail.